### PR TITLE
add path to json for each app

### DIFF
--- a/lib/application.json
+++ b/lib/application.json
@@ -6,8 +6,9 @@
   "icon": "terminal.png",
   "language": "EN-US",
   "type": "system",
-  "author": "noah cain @ dahlia"
-},
+  "author": "noah cain @ dahlia",
+  "path": "applications/terminal.dart"
+}
 "calculator": {
   "name": "Calculator",
   "theme": "0xFF4caf50",
@@ -15,7 +16,8 @@
   "icon": "calculator.png",
   "language": "EN-US",
   "type": "math",
-  "author": "horus @ dahlia"
+  "author": "horus @ dahlia",
+  "path": "applications/calculator.dart"
 },
 "notes": {
   "name": "Notes",
@@ -24,7 +26,8 @@
   "icon": "notes.png",
   "language": "EN-US",
   "type": "utilities",
-  "author": "horus @ dahlia"
+  "author": "horus @ dahlia",
+  "path": "applications/editor.dart"
 },
 "demo": {
   "name": "demo",
@@ -33,6 +36,7 @@
   "icon": "null.png",
   "language": "EN-US",
   "type": "none",
-  "author": "demo"
+  "author": "demo",
+  "path": "null"
 }
 }


### PR DESCRIPTION
In future when parsing json for “app drawer” it will be able to have path for launching apps. This is currently not handled as it only says “unable to parse json” in current build