### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+<uses-sdk
+    android:minSdkVersion="19"
+    android:targetSdkVersion="26" /> 
 </manifest>


### PR DESCRIPTION
Add minimum api level to fix issues with android 4.2-4.3. It uses a much older version of flutter, therefore making it not render properly.

Minimum api level: 19 (KitKat)
Target api level: 26+ (Oreo and above)