### PR TITLE
Fix poweroff, but in quicksettings

### DIFF
--- a/lib/quick_settings.dart
+++ b/lib/quick_settings.dart
@@ -169,7 +169,7 @@ class QuickSettingsState extends State<QuickSettings> {
                               padding: EdgeInsets.only(
                                   top: scale(20.0), right: scale(20)),
                               child: buildPowerItem(Icons.power_settings_new,
-                                  'Power off', 'shutdown', '-h now'),
+                                  'Power off', 'poweroff', '-f'),
                             ),
                             Padding(
                               padding: EdgeInsets.only(


### PR DESCRIPTION
There was a patch merged, (developer.dart) that fixed a poweroff issue. I'm now just pushing it to the quicksettings panel.